### PR TITLE
Clear canvas mapping before redraw

### DIFF
--- a/elektryka_gui.py
+++ b/elektryka_gui.py
@@ -246,6 +246,7 @@ class ElektrykaApp(tk.Tk):
     # --- RENDER ---
     def _redraw(self):
         self.canvas.delete("all")
+        self._id_to_model.clear()
         w = self.canvas.winfo_width()
         h = self.canvas.winfo_height()
         if self._grid_on.get():


### PR DESCRIPTION
## Summary
- clear the canvas ID to model mapping at the start of redraw to avoid stale references to deleted items

## Testing
- python -m compileall elektryka_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e55422c63883239a5cd058239d4878