### PR TITLE
Fix cross-room link rendering logic

### DIFF
--- a/elektryka.py
+++ b/elektryka.py
@@ -639,7 +639,7 @@ class ElektrykaApp:
             if only and pick and (link.circuit_id != pick): continue
             a = idx[link.a_id]
             color = self._circuit_color_hex(link.circuit_id)
-            if link.b_id in idx:
+            if link.b_id in idx and (not link.b_room or link.b_room == room.name):
                 b = idx[link.b_id]
                 self.canvas.create_line(a.x, a.y, b.x, b.y, fill=color, width=3, arrow="last")
             else:


### PR DESCRIPTION
## Summary
- ensure canvas treats links as local only when the target room matches the current room

## Testing
- python -m compileall elektryka.py

------
https://chatgpt.com/codex/tasks/task_e_68e554b0295883238139ffef538c17ce