### PR TITLE
Fix redraw to reset canvas id mapping

### DIFF
--- a/elektryka_gui.py
+++ b/elektryka_gui.py
@@ -246,6 +246,7 @@ class ElektrykaApp(tk.Tk):
     # --- RENDER ---
     def _redraw(self):
         self.canvas.delete("all")
+        self._id_to_model.clear()
         w = self.canvas.winfo_width()
         h = self.canvas.winfo_height()
         if self._grid_on.get():


### PR DESCRIPTION
## Summary
- clear the `_id_to_model` mapping whenever the canvas is redrawn to avoid stale ids

## Testing
- python -m compileall elektryka_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e555b8e5d48323b855e94ee5e9e06d