### PR TITLE
Fix cross-room link rendering collision

### DIFF
--- a/elektryka.py
+++ b/elektryka.py
@@ -639,7 +639,8 @@ class ElektrykaApp:
             if only and pick and (link.circuit_id != pick): continue
             a = idx[link.a_id]
             color = self._circuit_color_hex(link.circuit_id)
-            if link.b_id in idx:
+            is_local = (link.b_id in idx) and (not link.b_room or link.b_room == room.name)
+            if is_local:
                 b = idx[link.b_id]
                 self.canvas.create_line(a.x, a.y, b.x, b.y, fill=color, width=3, arrow="last")
             else:


### PR DESCRIPTION
## Summary
- ensure link drawing treats targets in other rooms as remote even when IDs overlap with local elements

## Testing
- python -m compileall elektryka.py

------
https://chatgpt.com/codex/tasks/task_e_68e555c854b083239e210f4357bb097e