### PR TITLE
Fix canvas id map lifecycle during redraw

### DIFF
--- a/elektryka_gui.py
+++ b/elektryka_gui.py
@@ -245,6 +245,7 @@ class ElektrykaApp(tk.Tk):
 
     # --- RENDER ---
     def _redraw(self):
+        self._id_to_model.clear()
         self.canvas.delete("all")
         w = self.canvas.winfo_width()
         h = self.canvas.winfo_height()


### PR DESCRIPTION
## Summary
- clear the canvas id-to-model mapping at the start of each redraw to drop stale ids

## Testing
- python -m compileall elektryka_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e5575879208323bbafe0f31fe8a493