### PR TITLE
Upgrade to v1.1.0 with circuit-aware cables

### DIFF
--- a/app/board_logic.py
+++ b/app/board_logic.py
@@ -1,5 +1,5 @@
 from typing import Optional, List
-from .models import Project, Element, Board, Cable
+from .models import Project, Element, Board, Cable, Circuit
 
 ET_COLORS = {
     "GNIAZDKO": "#1f77b4",
@@ -39,7 +39,15 @@ def find_board(project: Project, board_name: str) -> Optional[Board]:
     return None
 
 def validate_single_line(points: List[tuple]) -> List[tuple]:
-    # Upraszczamy trasę do odcinków łamanych: max 12 punktów, traktowanych jako „jedna linia”
     if len(points) > 12:
         return points[:12]
     return points
+
+def circuit_of_element(project: Project, el: Element) -> Optional[Circuit]:
+    if not el.circuit_id:
+        return None
+    for b in project.boards:
+        for c in b.circuits:
+            if c.id == el.circuit_id:
+                return c
+    return None

--- a/app/gui.py
+++ b/app/gui.py
@@ -3,14 +3,14 @@ from tkinter import ttk, messagebox, simpledialog
 from typing import Optional
 from .store import load_project, save_project
 from .models import Element, Cable, Board, Circuit, Project
-from .board_logic import ET_COLORS, next_symbol, validate_single_line
+from .board_logic import ET_COLORS, next_symbol, validate_single_line, circuit_of_element
 
 CANVAS_W, CANVAS_H = 1024, 576
 
 class ElektrykaApp(ttk.Frame):
     def __init__(self, master):
         super().__init__(master)
-        self.master.title("Domowy Elektryk — v1.0.0")
+        self.master.title("Domowy Elektryk — v1.1.0")
         self.pack(fill="both", expand=True)
         self.project: Project = load_project()
 
@@ -147,10 +147,20 @@ class ElektrykaApp(ttk.Frame):
     # ---------------- Plan / Canvas ----------------
     def _draw_canvas(self):
         self.canvas.delete("all")
-        # kable
+        # kable (kolor wg obwodu A lub B, jak brak — czarny)
         for cab in self.project.cables:
+            color = "#000000"
+            a = self._by_id(cab.a_element_id)
+            b = self._by_id(cab.b_element_id)
+            for el in (a, b):
+                if not el:
+                    continue
+                circ = circuit_of_element(self.project, el)
+                if circ and circ.color:
+                    color = circ.color
+                    break
             if cab.points:
-                self.canvas.create_line(*sum(cab.points, ()), width=2, smooth=True)
+                self.canvas.create_line(*sum(cab.points, ()), width=2, smooth=True, fill=color)
         # elementy
         for e in self.project.elements:
             color = ET_COLORS.get(e.etype, "#000")

--- a/app/models.py
+++ b/app/models.py
@@ -25,7 +25,7 @@ class Element:
 @dataclass
 class Circuit:
     id: str
-    name: str       # np. B16/O1 „Gniazda salon”
+    name: str       # np. O1 Gniazda Salon
     breaker: str    # np. B16, B10, C20
     rcd: Optional[str] = None  # np. 30mA
     color: str = "#000000"
@@ -45,12 +45,12 @@ class Cable:
     a_element_id: str
     b_element_id: str
     kind: str = "YDYp 3x1.5"
-    points: List[Tuple[int, int]] = field(default_factory=list)  # jedna linia (polyline), ale traktowana jako „jedna trasa”
+    points: List[Tuple[int, int]] = field(default_factory=list)  # jedna linia (polyline) jako „jedna trasa”
 
 @dataclass
 class Project:
     id: str
-    version: str = "1.0.0"
+    version: str = "1.1.0"
     name: str = "Domowy Elektryk — Projekt"
     boards: List[Board] = field(default_factory=list)
     elements: List[Element] = field(default_factory=list)

--- a/app/store.py
+++ b/app/store.py
@@ -26,7 +26,7 @@ def load_project() -> Project:
     # prosty parser
     proj = Project(
         id=raw.get("id","proj-0001"),
-        version=raw.get("version","1.0.0"),
+        version=raw.get("version","1.1.0"),
         name=raw.get("name","Domowy Elektryk — Projekt"),
     )
     # boards

--- a/data/project.json
+++ b/data/project.json
@@ -1,6 +1,6 @@
 {
   "id": "seed-proj",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "Domowy Elektryk — Projekt",
   "boards": [
     {


### PR DESCRIPTION
## Summary
- update the application metadata to version 1.1.0 across models, storage, and seed data
- add a helper to resolve an element's circuit and use its colour when drawing cables in the GUI

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e61307bbb88323a5ab7e0ddac62f34