### PR TITLE
Fix cable calculator result string concatenation

### DIFF
--- a/ui_calc.py
+++ b/ui_calc.py
@@ -78,7 +78,9 @@ class CableCalculatorDialog(tk.Toplevel):
             cross_section = "4 mm²"
 
         self.result_var.set(
-            f"I = {current:.2f} A, spadek ≈ {voltage_drop_percent:.2f}%, "
-            f"zalecany przewód: {cross_section}"
+            (
+                f"I = {current:.2f} A, spadek ≈ {voltage_drop_percent:.2f}%, "
+                f"zalecany przewód: {cross_section}"
+            )
         )
 


### PR DESCRIPTION
## Summary
- ensure the cable calculator passes a single concatenated string to `StringVar.set`

## Testing
- python -m py_compile elektryka.py ui_calc.py

------
https://chatgpt.com/codex/tasks/task_e_68ea1aba141c83238423192cf19c8665