### PR TITLE
Fix snapped plan coordinates clamping

### DIFF
--- a/app/gui.py
+++ b/app/gui.py
@@ -266,7 +266,9 @@ class ElektrykaApp(ttk.Frame):
             return x, y
         gx = round(x / self.grid_size) * self.grid_size
         gy = round(y / self.grid_size) * self.grid_size
-        return int(gx), int(gy)
+        gx = clamp(int(gx), 0, CANVAS_W)
+        gy = clamp(int(gy), 0, CANVAS_H)
+        return gx, gy
 
     def _toggle_grid(self):
         self.show_grid = bool(self.var_show_grid.get())


### PR DESCRIPTION
## Summary
- clamp snapped plan coordinates to the canvas bounds so elements stay visible

## Testing
- python -m compileall app/gui.py

------
https://chatgpt.com/codex/tasks/task_e_68ea2f2da63883239d75b9109f652e07